### PR TITLE
Update starline_api.py

### DIFF
--- a/starline/starline_api.py
+++ b/starline/starline_api.py
@@ -64,7 +64,7 @@ class StarlineApi(BaseApi):
                 continue
 
             data = response["obd_params"]
-            if data["errors"] and data["errors"]["val"] > 0:
+            if "errors" in data and data["errors"] and data["errors"]["val"] > 0:
                 data["errors"]["errors"] = self.get_obd_errors(device_id)
 
             self._devices[device_id].update_obd(data)


### PR DESCRIPTION
если нет у сигналки OBD то и нет этого ключи, из-за этого падает интеграция целиком в Homeassistant